### PR TITLE
Update to scala 2.12.x, sbt 1.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,19 +7,16 @@ sbtPlugin := true
 
 publishArtifact in Test := false
 
-scalaVersion := "2.10.5"
+scalaVersion := "2.12.4"
 
 bintrayOrganization := Some("joprice")
 
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
-ScriptedPlugin.scriptedSettings
-
-scriptedSettings
+ScriptedPlugin.projectSettings
 
 scriptedBufferLog := false
 
 scriptedLaunchOpts ++= Seq("-Xmx2G", "-Dplugin.version=" + version.value)
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8")
-

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=1.1.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,8 @@
+resolvers += Resolver.sbtPluginRepo("releases")
 
-resolvers += Resolver.url("bintray-sbt-plugin-releases",
-  url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+resolvers += Resolver.bintrayRepo("sbt", "maven-releases")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
-
-libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
-
+libraryDependencies += "org.scala-sbt" % s"scripted-plugin_${scalaBinaryVersion.value}" % sbtVersion.value

--- a/src/main/scala/com/github/joprice/JniPlugin.scala
+++ b/src/main/scala/com/github/joprice/JniPlugin.scala
@@ -2,9 +2,13 @@ package com.github.joprice
 
 import sbt._
 import Keys._
+
 import scala.language.postfixOps
 import java.io.File
+
 import plugins.JvmPlugin
+
+import scala.sys.process.Process
 
 object JniPlugin extends AutoPlugin { self =>
 
@@ -120,7 +124,7 @@ object JniPlugin extends AutoPlugin { self =>
       val classes = (fullClasspath in Compile).value.map(_.data).mkString(File.pathSeparator)
       val javahCommand = s"javah -d ${jniHeadersPath.value} -classpath $classes ${jniNativeClasses.value.mkString(" ")}"
       log.info(javahCommand)
-      checkExitCode("javah", javahCommand ! log)
+      checkExitCode("javah", Process(javahCommand) ! log)
     }.dependsOn(compile in Compile)
      .tag(Tags.Compile, Tags.CPU)
      .value,


### PR DESCRIPTION
- Update: scala 2.10.5 -> 2.12.4, sbt 0.13.9 -> 1.1.2.
- Rename: `ScriptedPlugin#scriptedSettings` -> `ScriptedPlugin#projectSettings` ([scripted v0.13.17](https://github.com/sbt/sbt/blob/v0.13.17/scripted/plugin/src/main/scala/sbt/ScriptedPlugin.scala) -> [scripted v1.1.2](https://github.com/sbt/sbt/blob/v1.1.2/scripted/plugin/src/main/scala/sbt/ScriptedPlugin.scala))
- Import `scala.sys.process.Process`: at sbt 1.0, `sbt.Process` and `sbt.ProcessExtra` were dropped. ([1.0 release note](https://www.scala-sbt.org/1.x/docs/sbt-1.0-Release-Notes.html))