### PR TITLE
Support empty jniNativeClasses

### DIFF
--- a/src/main/scala/com/github/joprice/JniPlugin.scala
+++ b/src/main/scala/com/github/joprice/JniPlugin.scala
@@ -141,7 +141,7 @@ object JniPlugin extends AutoPlugin { self =>
         }.dependsOn(compile in Compile)
          .tag(Tags.Compile, Tags.CPU)
       }
-    },
+    }.value,
     jniPossibleNativeSources := {
       def withExtension(dir: File, extension: String) = (dir ** s"*.$extension").filter(_.isFile).get
 

--- a/src/main/scala/com/github/joprice/JniPlugin.scala
+++ b/src/main/scala/com/github/joprice/JniPlugin.scala
@@ -124,15 +124,24 @@ object JniPlugin extends AutoPlugin { self =>
     }.dependsOn(jniJavah)
      .tag(Tags.Compile, Tags.CPU)
      .value,
-    jniJavah := Def.task {
-      val log = streams.value.log
-      val classes = (fullClasspath in Compile).value.map(_.data).mkString(File.pathSeparator)
-      val javahCommand = s"javah -d ${jniHeadersPath.value} -classpath $classes ${jniNativeClasses.value.mkString(" ")}"
-      log.info(javahCommand)
-      checkExitCode("javah", Process(javahCommand) ! log)
-    }.dependsOn(compile in Compile)
-     .tag(Tags.Compile, Tags.CPU)
-     .value,
+    jniJavah := Def.taskDyn {
+      if (!jniNativeClasses.value.isEmpty) {
+        Def.task {
+          val log = streams.value.log
+          val classes = (fullClasspath in Compile).value.map(_.data).mkString(File.pathSeparator)
+          val javahCommand = s"javah -d ${jniHeadersPath.value} -classpath $classes ${jniNativeClasses.value.mkString(" ")}"
+          log.info(javahCommand)
+          checkExitCode("javah", Process(javahCommand) ! log)
+        }.dependsOn(compile in Compile)
+         .tag(Tags.Compile, Tags.CPU)
+      } else {
+        Def.task{
+          val log = streams.value.log
+          log.info("jniNativeClasses is empty: skipping header generation.")
+        }.dependsOn(compile in Compile)
+         .tag(Tags.Compile, Tags.CPU)
+      }
+    },
     jniPossibleNativeSources := {
       def withExtension(dir: File, extension: String) = (dir ** s"*.$extension").filter(_.isFile).get
 


### PR DESCRIPTION
If the JNI project depends on a library like [JinHelpers](https://github.com/spotify/JniHelpers), the header files don't need to be generated by javah. However, the current implementation returns error when `jniNativeClasses` setting is empty - in this case, the user must go around by [overriding the jniJavah task.](https://github.com/dongjinleekr/beanpiece/blob/7406de4fe5e2b92af4883c9e0d9caeb0bf9ff5eb/build.sbt#L77)

This update makes to allow the empty `jniNativeClasses` setting.