### PR TITLE
Support library flags: add jniLibraries settings key.

### DIFF
--- a/src/main/scala/com/github/joprice/JniPlugin.scala
+++ b/src/main/scala/com/github/joprice/JniPlugin.scala
@@ -43,6 +43,8 @@ object JniPlugin extends AutoPlugin { self =>
 
     lazy val jniIncludes = settingKey[Seq[String]]("Compiler includes settings")
 
+    lazy val jniLibraries = settingKey[Seq[String]]("Compiler libraries settings")
+
     lazy val jniSourceFiles = settingKey[Seq[File]]("Jni source files")
 
     lazy val jniGccFlags = settingKey[Seq[String]]("Flags to be passed to gcc")
@@ -94,6 +96,7 @@ object JniPlugin extends AutoPlugin { self =>
       "-I/usr/include",
       "-L/usr/local/include"
     ) ++ jniJreIncludes.value,
+    jniLibraries := Seq.empty,
     jniUseCpp11 := true,
     // 'dylib' and 'jnilib' work on mac, while linux expects 'so'
     jniLibSuffix := "jnilib",
@@ -111,9 +114,11 @@ object JniPlugin extends AutoPlugin { self =>
     jniCompile := Def.task {
       val log = streams.value.log
       jniBinPath.value.getAbsoluteFile.mkdirs()
-      val sources = jniSourceFiles.value.mkString(" ")
       val flags = jniGccFlags.value.mkString(" ")
-      val command = s"${jniNativeCompiler.value} $flags -o ${jniBinPath.value}/lib${jniLibraryName.value}.${jniLibSuffix.value} $sources"
+      val sources = jniSourceFiles.value.mkString(" ")
+      val libs = jniLibraries.value.mkString(" ")
+      val target = jniBinPath.value / ("lib" + jniLibraryName.value + "." + jniLibSuffix.value)
+      val command = s"${jniNativeCompiler.value} $flags -o ${target} $sources $libs"
       log.info(command)
       checkExitCode(jniNativeCompiler.value, Process(command, jniBinPath.value) ! log)
     }.dependsOn(jniJavah)


### PR DESCRIPTION
If you need to link libraries with a compiler(gcc or g++), [the library parameters(`-Lxxx`, `-lxxx`) should be supplied after the object files](https://stackoverflow.com/questions/14623415/gcc-g-parameter-order). This is also why [maven-native plugin supports three kinds of options](https://www.mojohaus.org/maven-native/native-maven-plugin/link-mojo.html), i.e., `linkerStartOptions`, `linkerMiddleOptions`, and `linkerEndOptions`.

With the current implementation, the user should go around [by overriding the `jniCompile` task.](https://github.com/dongjinleekr/beanpiece/blob/7406de4fe5e2b92af4883c9e0d9caeb0bf9ff5eb/build.sbt#L82) This update removes this inconvenience by adding `jniLibraries` setting.