### PR TITLE
Add option to disable generating C headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Update sbt to 1.3.13 and scala to 2.12.12
 * Remove the flags "-I/usr/include" and "-L/usr/local/include" that were added to jniIncludes
   by default, as they were conflicting with the gcc version provided by nix.
+* Add option to disable generating C header files
 
 ## v0.2.0
 * Update sbt to 1.1.2


### PR DESCRIPTION
The `jniGenerateHeaders` (by default `true`) controls whether C header files will be generated.